### PR TITLE
Optimization of deletion of children

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,13 +1,19 @@
 # Release history
 
-## V0.5.2
+## vNEXT
+
+### Kill them all, but fast
+Improvement has been made on the internal method `_destroyChildren` which should make
+the call of `clearContent` and `destroy` faster to execute.
+
+## v0.5.2
 
 ### toggle the display and tell me what
 The `toggleDisplay` now returns the status of the display.
 Also fixed a bug where passing an `undefined` variable will always toggle on.
 
 
-## V0.5.1
+## v0.5.1
 
 ### Pimp my style
 A new method `getComputedStyles` allows to retrieve multiple computed style properties in one call.

--- a/component.json
+++ b/component.json
@@ -9,6 +9,7 @@
 	},
 	"scripts": [
 		"index.js",
-		"domEvents.js"
+		"domEvents.js",
+		"shim.js"
 	]
 }

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
 var inherit = require('util').inherits;
 var EventEmitter = require('events').EventEmitter;
 var domEvents = require('./domEvents.js');
+require('./shim.js');
 
 var cType = {
 	EMPTY: null,
@@ -628,14 +629,34 @@ WuiDom.prototype.toggleClassNames = function (classNames, shouldAdd) {
 };
 
 
+WuiDom.prototype._removeDom = function () {
+	var elm = this.rootElement;
+	if (elm) {
+		// release DOM from the DOM tree
+		elm.remove();
+		// drop DOM references
+		this.rootElement = null;
+	}
+};
+
 /**
  * Destroy all children of a WuiDom
  * @private
  */
 WuiDom.prototype._destroyChildren = function () {
 	var children = this._childrenList.concat();
+	this._childrenList = [];
+	this._childrenMap = {};
+
 	for (var i = 0, len = children.length; i < len; i += 1) {
-		children[i].destroy();
+		var child = children[i];
+
+		child.emit('destroy');
+
+		child._parent = null;
+		child._destroyChildren();
+		child._removeDom();
+		child.removeAllListeners();
 	}
 };
 
@@ -666,28 +687,13 @@ WuiDom.prototype.destroy = function () {
 	this.emit('destroy');
 
 	// clean siblings
-
 	this._unsetParent();
 	this._destroyChildren();
 
 	// cleanup DOM tree
-
-	var elm = this.rootElement;
-
-	if (elm) {
-		// release DOM from parent element
-
-		if (elm.parentElement) {
-			elm.parentElement.removeChild(elm);
-		}
-
-		// drop DOM references
-
-		this.rootElement = null;
-	}
+	this._removeDom();
 
 	// drop any remaining event listeners
-
 	this.removeAllListeners();
 };
 

--- a/shim.js
+++ b/shim.js
@@ -1,0 +1,10 @@
+var ElementPrototype = Element.prototype;
+
+if (!ElementPrototype.remove) {
+	ElementPrototype.remove = function remove() {
+		var parentNode = this.parentNode;
+		if (parentNode) {
+			parentNode.removeChild(this);
+		}
+	};
+}


### PR DESCRIPTION
`_destroyChildren` stop being recursive on `destroy` which was calling `unsetParent` for every children.

With this modification I could observe a boost on big tree deletion speed of 35%.


### Included
A premise of the upcoming dom shim, for an API easy to read using new and fast API on the DOM.
We will probably use dom-shims in a near future, waiting for PR https://github.com/necolas/dom-shims/pull/8 to be merged.